### PR TITLE
First working version of mpi test decorator

### DIFF
--- a/testsuite/pytests/utilities/test_brunel2000_mpi.py
+++ b/testsuite/pytests/utilities/test_brunel2000_mpi.py
@@ -19,13 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-import nest
-import numpy as np
-import pandas as pd
-import pytest
-from mpi_wrapper import mpi_assert_equal_df
 
-# from mpi4py import MPI
+from mpi_wrapper import mpi_assert_equal_df
 
 
 @mpi_assert_equal_df([1, 2])
@@ -40,14 +35,16 @@ def test_brunel2000():
     183-208 (2000).
     """
 
+    import nest
+
     nest.ResetKernel()
 
     nest.set(total_num_virtual_procs=2)
 
     # Model parameters
-    NE = 10_000  # number of excitatory neurons
-    NI = 2_500  # number of inhibitory neurons
-    CE = 1_000  # number of excitatory synapses per neuron
+    NE = 1000  # number of excitatory neurons
+    NI = 250  # number of inhibitory neurons
+    CE = 100  # number of excitatory synapses per neuron
     CI = 250  # number of inhibitory synapses per neuron
     N_rec = 10  # number of (excitatory) neurons to record
     D = 1.5  # synaptic delay, all connections [ms]
@@ -76,7 +73,7 @@ def test_brunel2000():
     enodes = nest.Create("iaf_psc_delta", NE, params=neuron_params)
     inodes = nest.Create("iaf_psc_delta", NI, params=neuron_params)
     ext = nest.Create("poisson_generator", 1, params={"rate": nu_ext * CE * 1000.0})
-    srec = nest.Create("spike_recorder", 1)
+    srec = nest.Create("spike_recorder", 1, params={"label": f"sr_{nest.num_processes:02d}", "record_to": "ascii"})
 
     nest.CopyModel("static_synapse", "esyn", params={"weight": JE, "delay": D})
     nest.CopyModel("static_synapse", "isyn", params={"weight": JI, "delay": D})
@@ -98,6 +95,7 @@ def test_brunel2000():
     )
 
     # Simulate network
-    nest.Simulate(200.0)
+    nest.Simulate(400)
 
-    return pd.DataFrame.from_records(srec.events)
+    # next variant is for testing the test
+    # nest.Simulate(200 if nest.num_processes == 1 else 400)


### PR DESCRIPTION
Hei @nicolossus,

Her er en versjon som fungerer. Det var i det vesentlige to ting jeg måtte fikse:
- `mpi_wrapper` må ikke importeres fra `runner.py`, siden den ikke er i tmpdir; kan være dette problemet forsvinner når wrapperen defineres på "ordentlig" sted
- I `test_brunel_...` må selve `import nest` legges i test-funksjonen, slik at `nest` ikke importeres når pytest kjører `test_....py` skriptet. Da starter den opp MPI og det fører til forvirring og problemene.

Videre har jeg endret skriptet slik at den skriver spikedata til fil og så sammenlikner data fra fil. Jeg tror vi skal gå for en slik løsning for å unngå at det blir krøll når MPI prosessene skriver data til pipene. Da har jo det gamle systemet vært noe ustabilt.

Med det mest vesentlige løst kan jeg nå begynne å tenke på detaljene. Sjekken som den er bygget inn å er jo rimelig spesifisk for tester som produserer spiketog med tid i ms. Men det største problemet er ute av veien :).